### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `openpyxl` instead of `xlrd` as the latter doesn't support .xlsx format anymore.
+
+### Added
+- Added [`openpyxl`](https://openpyxl.readthedocs.io/en/stable/changes.html)
+
+### Removed
+- Removed [`xlrd`](https://xlrd.readthedocs.io/en/latest/changes.html)
 
 ## [2.3.0] - 2019-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.0] - 2021-01-18
 ### Changed
 - Use `openpyxl` instead of `xlrd` as the latter doesn't support .xlsx format anymore.
 
@@ -18,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/tesxcel/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/Colin-b/tesxcel/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/Colin-b/tesxcel/compare/v2.3.0...v3.0.0
 [2.3.0]: https://github.com/Colin-b/tesxcel/releases/tag/v2.3.0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 </p>
 
 Ensure that two Microsoft Excel files have the same cell types and content in every sheet.
+Supported file formats are: `.xlsx`, `.xlsm`, `.xltx`, `.xltm`
 
 ```python
 import tesxcel

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used to read Microsoft Excel file content
-        "xlrd==1.*"
+        "openpyxl==3.*"
     ],
     extras_require={
         "testing": [

--- a/tesxcel/_excel.py
+++ b/tesxcel/_excel.py
@@ -1,45 +1,43 @@
 from typing import Union
-import xlrd
-from xlrd.sheet import Sheet
+import openpyxl
+from io import BytesIO
 
 
 def assert_excel_content(
     file_path_or_actual_content: Union[str, bytes], expected_file_path: str
 ):
     if isinstance(file_path_or_actual_content, str):
-        actual_workbook = xlrd.open_workbook(file_path_or_actual_content)
+        actual_workbook = openpyxl.open(file_path_or_actual_content)
     else:
-        actual_workbook = xlrd.open_workbook(file_contents=file_path_or_actual_content)
-    expected_workbook = xlrd.open_workbook(expected_file_path)
-
-    assert sorted(actual_workbook.sheet_names()) == sorted(
-        expected_workbook.sheet_names()
+        actual_workbook = openpyxl.load_workbook(BytesIO(file_path_or_actual_content))
+    expected_workbook = openpyxl.open(expected_file_path)
+    print()
+    assert sorted(actual_workbook.sheetnames) == sorted(
+        expected_workbook.sheetnames
     ), "Different sheet names"
 
-    for sheet_name in actual_workbook.sheet_names():
+    for sheet_name in actual_workbook.sheetnames:
         _assert_sheet_content(
             sheet_name,
-            actual_workbook.sheet_by_name(sheet_name),
-            expected_workbook.sheet_by_name(sheet_name),
+            actual_workbook.get_sheet_by_name(sheet_name),
+            expected_workbook.get_sheet_by_name(sheet_name),
         )
 
 
-def _assert_sheet_content(
-    sheet_name: str, actual_worksheet: Sheet, expected_worksheet: Sheet
-):
+def _assert_sheet_content(sheet_name: str, actual_worksheet, expected_worksheet):
     assert (
-        actual_worksheet.nrows == expected_worksheet.nrows
+        actual_worksheet.max_row == expected_worksheet.max_row
     ), f"Different number of rows in {sheet_name} sheet"
     assert (
-        actual_worksheet.ncols == expected_worksheet.ncols
+        actual_worksheet.max_column == expected_worksheet.max_column
     ), f"Different number of columns in {sheet_name} sheet"
 
-    for row_index, actual_row in enumerate(actual_worksheet.get_rows()):
-        expected_row = expected_worksheet.row(row_index)
+    for row_index, actual_row in enumerate(actual_worksheet.rows):
+        expected_row = expected_worksheet[row_index + 1]
         for cell_index, actual_cell in enumerate(actual_row):
             expected_cell = expected_row[cell_index]
             assert (
-                actual_cell.ctype == expected_cell.ctype
+                actual_cell.data_type == expected_cell.data_type
             ), f"Different cell type in row {row_index}, col {cell_index} in {sheet_name} sheet"
             assert (
                 actual_cell.value == expected_cell.value

--- a/tesxcel/_excel.py
+++ b/tesxcel/_excel.py
@@ -11,7 +11,6 @@ def assert_excel_content(
     else:
         actual_workbook = openpyxl.load_workbook(BytesIO(file_path_or_actual_content))
     expected_workbook = openpyxl.open(expected_file_path)
-    print()
     assert sorted(actual_workbook.sheetnames) == sorted(
         expected_workbook.sheetnames
     ), "Different sheet names"

--- a/tesxcel/version.py
+++ b/tesxcel/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "2.3.0"
+__version__ = "3.0.0"


### PR DESCRIPTION
### Changed
- Use `openpyxl` instead of `xlrd` as the latter doesn't support .xlsx format anymore.

### Added
- Added [`openpyxl`](https://openpyxl.readthedocs.io/en/stable/changes.html)

### Removed
- Removed [`xlrd`](https://xlrd.readthedocs.io/en/latest/changes.html)
